### PR TITLE
Add interactive React landing page, about page, styles, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Fangzhi Zhao
-**This is a website project by Fangzhi Zhao, hosted on GitHub.**
-You can reach this site by each on of the following:
-* [fangzhizhao.github.io](http://fangzhizhao.github.io)
-* [github.fangzhizhao.net](http://github.fangzhizhao.net)
 
-You can also visit my portfolio site for other work:
-* [fangzhizhao.net](http://fangzhizhao.net)
+This repository hosts Fangzhi Zhao's GitHub Pages website.
+
+## Pages
+
+- `/` — Main landing page (React (CDN) + interactive particle art)
+- `/about/` — About page scaffold (coming soon)
+- `/first-github-page/` — Archived original page, marked as the very first GitHub page
+
+## External links
+
+- Main portfolio: [fangzhizhao.net](http://fangzhizhao.net)
+- Blog: [marketingos.blog](https://marketingos.blog)

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About · Fangzhi Zhao</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #080b13;
+        --text: #ecf2ff;
+        --muted: #c8d3e7;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background: radial-gradient(circle at 20% 20%, #11192b 0%, var(--bg) 52%);
+        color: var(--text);
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      }
+
+      .wrap {
+        width: min(92vw, 860px);
+        margin: 0 auto;
+        padding: 1rem 0 3rem;
+      }
+
+      .nav {
+        display: flex;
+        justify-content: center;
+        gap: 0.9rem;
+        margin-bottom: 1rem;
+      }
+
+      .nav a {
+        border: 1px solid rgba(255, 255, 255, 0.24);
+        background: linear-gradient(
+          140deg,
+          rgba(255, 255, 255, 0.16) 0%,
+          rgba(255, 255, 255, 0.04) 45%,
+          rgba(255, 255, 255, 0.08) 100%
+        );
+        color: var(--text);
+        border-radius: 999px;
+        padding: 0.56rem 1rem;
+        text-decoration: none;
+        backdrop-filter: blur(14px) saturate(140%);
+        -webkit-backdrop-filter: blur(14px) saturate(140%);
+      }
+
+      .glass {
+        background: linear-gradient(
+          155deg,
+          rgba(255, 255, 255, 0.14),
+          rgba(255, 255, 255, 0.04) 35%,
+          rgba(8, 11, 19, 0.55) 100%
+        );
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        border-radius: 18px;
+        backdrop-filter: blur(12px) saturate(140%);
+        -webkit-backdrop-filter: blur(12px) saturate(140%);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 18px 55px rgba(0, 0, 0, 0.45);
+      }
+
+      .hero {
+        padding: 1.2rem 1.3rem;
+        margin-bottom: 0.9rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 6vw, 3.3rem);
+      }
+
+      .pronounce {
+        margin-top: 0.35rem;
+        color: #d7e4fd;
+        font-size: 0.95rem;
+        letter-spacing: 0.04em;
+      }
+
+      .prose {
+        padding: 1.4rem;
+      }
+
+      .prose p {
+        margin: 0 0 1.15rem;
+        color: var(--muted);
+        line-height: 1.78;
+        font-size: clamp(1rem, 2vw, 1.08rem);
+      }
+
+      .prose p:last-child {
+        margin-bottom: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <nav class="nav" aria-label="Main">
+        <a href="https://marketingos.blog" target="_blank" rel="noreferrer">Blog</a>
+        <a href="/about/">About</a>
+        <a href="/">Home</a>
+      </nav>
+
+      <section class="hero glass">
+        <h1>Fangzhi Zhao</h1>
+        <div class="pronounce">FANG-ZEE JAO</div>
+      </section>
+
+      <article class="prose glass">
+        <p>
+          I work at the intersection of marketing, AI, systems, and art. Not as separate disciplines,
+          but as one evolving practice.
+        </p>
+
+        <p>
+          I’m interested in how brands are built when content becomes a living engine, when systems
+          scale intuition, and when technology amplifies, rather than replaces, human emotion. I think
+          a lot about emotional resonance: why some ideas stick, why some brands feel alive, and why
+          others disappear into noise.
+        </p>
+
+        <p>
+          My work lives where product, content, and community overlap. I design narratives, content
+          ecosystems, and creator-driven systems that don’t just perform, but compound. Growth, to me,
+          isn’t a spike. It’s an outcome of clarity, consistency, and trust built over time.
+        </p>
+
+        <p>
+          I started in design and once thought I’d become a fine artist. That background still defines
+          how I see the world. Art taught me that the most compelling work exists at the edge between
+          control and loss of control, structure and chaos. Marketing is no different. Data can guide
+          you, but it can’t replace taste, intuition, or courage. Metrics explain what happened. They
+          don’t tell you what’s worth making next.
+        </p>
+
+        <p>
+          This blog is where I think out loud. About brand building in the age of AI. About content
+          systems that scale without losing soul. About creativity, strategy, and the uncomfortable
+          middle ground where real insight tends to live.
+        </p>
+
+        <p>
+          If you’re curious about how ideas turn into systems, and how systems can still feel human,
+          you’re in the right place.
+        </p>
+      </article>
+    </div>
+  </body>
+</html>

--- a/css/site.css
+++ b/css/site.css
@@ -1,0 +1,133 @@
+:root {
+  --bg: #080b13;
+  --text: #ecf2ff;
+  --muted: #a4b3cc;
+  --accent: #71c7ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: radial-gradient(circle at 20% 20%, #11192b 0%, var(--bg) 52%);
+  color: var(--text);
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  overflow: hidden;
+}
+
+.site {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+canvas {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.nav {
+  position: fixed;
+  top: env(safe-area-inset-top, 0);
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 0.9rem;
+  z-index: 3;
+  padding: 1rem;
+}
+
+.nav a {
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: linear-gradient(
+    140deg,
+    rgba(255, 255, 255, 0.16) 0%,
+    rgba(255, 255, 255, 0.04) 45%,
+    rgba(255, 255, 255, 0.08) 100%
+  );
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.56rem 1rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.26), 0 10px 30px rgba(0, 0, 0, 0.28);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.nav a:hover {
+  transform: translateY(-1px);
+  border-color: rgba(113, 199, 255, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.34), 0 0 20px rgba(113, 199, 255, 0.24);
+}
+
+.centerpiece {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.center-card {
+  background: linear-gradient(
+    155deg,
+    rgba(255, 255, 255, 0.14),
+    rgba(255, 255, 255, 0.04) 35%,
+    rgba(8, 11, 19, 0.55) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 18px;
+  padding: clamp(1rem, 3vw, 1.4rem) clamp(1.1rem, 4vw, 1.8rem);
+  min-width: min(86vw, 560px);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 18px 55px rgba(0, 0, 0, 0.45);
+}
+
+.centerpiece h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 7.8vw, 5rem);
+  letter-spacing: 0.03em;
+  text-shadow: 0 8px 40px rgba(113, 199, 255, 0.22);
+}
+
+.tagline {
+  margin-top: 0.8rem;
+  margin-bottom: 0.3rem;
+  color: #dce6fa;
+  font-size: clamp(1rem, 2.3vw, 1.2rem);
+}
+
+.shape {
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(0.85rem, 2vw, 1rem);
+}
+
+@media (max-width: 700px) {
+  .nav {
+    justify-content: flex-start;
+    padding: 0.85rem;
+  }
+
+  .center-card {
+    min-width: min(92vw, 560px);
+  }
+}

--- a/first-github-page/index.html
+++ b/first-github-page/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Fangzhi Zhao GitHub</title>
+		<link href="../css/main.css" rel="stylesheet">
+		<meta charset="UTF-8">
+
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+		<script src="../js/main.js" type="text/javascript"></script>
+		<script src="../js/speak.js" type="text/javascript"></script>
+	</head>
+
+	<body>
+		<div style="background:#111;color:#fff;display:inline-block;padding:8px 12px;border-radius:8px;font-weight:700;margin-bottom:12px;">
+			My very first GitHub page
+		</div>
+		<h1><a href="http://fangzhizhao.net">Fangzhi Zhao</a></h1>
+		
+		<p>
+			Go to Fangzhi's main site!<br>
+			去往放之主站！<br>
+			And check out more work!<br>
+			查看更多作品！
+		</p>
+
+		<!-- Moving star -->
+		<div id="container">
+			<div class="a"><img src="https://upload.wikimedia.org/wikipedia/en/e/e5/Yellow_Star.png"></div>
+		</div>
+
+		<!-- Thumbnail container -->
+		<div id = "thumbnails">
+
+		    <a href="http://fangzhizhao.net/Possessed-11m-35s">
+				 <figure class="tint"><img src="../imgs/465458471.gif" alt="thumb"></figure>
+			</a>
+
+			 <figure class="tint"><img src="../imgs/face-swap.gif" alt="faceswap"></figure>
+			
+			<a href="http://fangzhizhao.net/Gallery-Graffiti">
+				 <figure class="tint"><img src="../imgs/gg_tb.gif" alt="grafiti"></figure>
+			</a>
+
+			<a href="http://fangzhizhao.net/Selfie-with-Computer-Girl-Flags-and-Doritos">
+				 <figure class="tint"><img src="../imgs/gmod.gif" alt="gmod"></figure>
+			</a>
+
+			<a href="http://fangzhizhao.net/Website-Erasing">
+				 <figure class="tint"><img src="../imgs/prt_200x200_1461445074_2x.gif" alt="Website-Erasing"></figure>
+			</a>
+
+			<a href="http://fangzhizhao.net/WeChat-Flash-Mob">
+				 <figure class="tint"><img src="../imgs/icon.gif" alt="selfie"></figure>
+			</a>
+		</div>
+
+		<!-- TTS script -->
+		<script type="text/javascript">
+			setInterval(function(){speak("Go to Fangzhi's main site")}, 3000);
+	    </script>
+	    
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,60 +1,22 @@
-<!DOCTYPE html>
-<html>
-	<head>
-		<title>Fangzhi Zhao GitHub</title>
-		<link href="css/main.css" rel="stylesheet">
-		<meta charset="UTF-8">
-
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-		<script src="js/main.js" type="text/javascript"></script>
-		<script src="js/speak.js" type="text/javascript"></script>
-	</head>
-
-	<body>
-		<h1><a href="http://fangzhizhao.net">Fangzhi Zhao</a></h1>
-		
-		<p>
-			Go to Fangzhi's main site!<br>
-			去往放之主站！<br>
-			And check out more work!<br>
-			查看更多作品！
-		</p>
-
-		<!-- Moving star -->
-		<div id="container">
-			<div class="a"><img src="https://upload.wikimedia.org/wikipedia/en/e/e5/Yellow_Star.png"></div>
-		</div>
-
-		<!-- Thumbnail container -->
-		<div id = "thumbnails">
-
-		    <a href="http://fangzhizhao.net/Possessed-11m-35s">
-				 <figure class="tint"><img src="imgs/465458471.gif" alt="thumb"></figure>
-			</a>
-
-			 <figure class="tint"><img src="imgs/face-swap.gif" alt="faceswap"></figure>
-			
-			<a href="http://fangzhizhao.net/Gallery-Graffiti">
-				 <figure class="tint"><img src="imgs/gg_tb.gif" alt="grafiti"></figure>
-			</a>
-
-			<a href="http://fangzhizhao.net/Selfie-with-Computer-Girl-Flags-and-Doritos">
-				 <figure class="tint"><img src="imgs/gmod.gif" alt="gmod"></figure>
-			</a>
-
-			<a href="http://fangzhizhao.net/Website-Erasing">
-				 <figure class="tint"><img src="imgs/prt_200x200_1461445074_2x.gif" alt="Website-Erasing"></figure>
-			</a>
-
-			<a href="http://fangzhizhao.net/WeChat-Flash-Mob">
-				 <figure class="tint"><img src="imgs/icon.gif" alt="selfie"></figure>
-			</a>
-		</div>
-
-		<!-- TTS script -->
-		<script type="text/javascript">
-			setInterval(function(){speak("Go to Fangzhi's main site")}, 3000);
-	    </script>
-	    
-	</body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fangzhi Zhao</title>
+    <link rel="stylesheet" href="css/site.css" />
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+  </head>
+  <body>
+    <div id="root">
+      <main style="min-height:100vh;display:grid;place-items:center;background:#080b13;color:#ecf2ff;font-family:Inter,system-ui,sans-serif;text-align:center;padding:24px;">
+        <div>
+          <h1 style="margin:0 0 12px;font-size:clamp(2rem,8vw,4.5rem);">Fangzhi Zhao</h1>
+          <p style="margin:0;color:#a4b3cc;">Loading new interactive landing page…</p>
+        </div>
+      </main>
+    </div>
+    <script src="js/app.js"></script>
+  </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,327 @@
+const { useEffect, useRef, useState } = React;
+
+function makePointsForShape(kind, width, height, isMobile) {
+  const off = document.createElement("canvas");
+  const w = Math.floor(Math.min(width * 0.66, 660));
+  const h = Math.floor(Math.min(height * 0.5, 420));
+  off.width = w;
+  off.height = h;
+  const ctx = off.getContext("2d");
+
+  ctx.clearRect(0, 0, w, h);
+  ctx.strokeStyle = "#fff";
+  ctx.fillStyle = "#fff";
+  ctx.lineWidth = Math.max(4, Math.min(w, h) * 0.03);
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+
+  if (kind === "globe") {
+    const r = Math.min(w, h) * 0.28;
+    const cx = w * 0.5;
+    const cy = h * 0.5;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+
+    for (const ratio of [0.45, 0.75]) {
+      ctx.beginPath();
+      ctx.ellipse(cx, cy, r * ratio, r, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    for (const y of [-0.45, 0, 0.45]) {
+      const ry = r * Math.cos(Math.asin(Math.min(0.95, Math.abs(y))));
+      ctx.beginPath();
+      ctx.ellipse(cx, cy + r * y, r, ry, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  } else if (kind === "face") {
+    const r = Math.min(w, h) * 0.27;
+    const cx = w * 0.5;
+    const cy = h * 0.5;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+
+    const eyeR = r * 0.1;
+    ctx.beginPath();
+    ctx.arc(cx - r * 0.36, cy - r * 0.18, eyeR, 0, Math.PI * 2);
+    ctx.arc(cx + r * 0.36, cy - r * 0.18, eyeR, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.arc(cx, cy + r * 0.1, r * 0.48, 0.18 * Math.PI, 0.82 * Math.PI, false);
+    ctx.stroke();
+  } else if (kind === "mac") {
+    const x = w * 0.2;
+    const y = h * 0.2;
+    const bw = w * 0.6;
+    const bh = h * 0.45;
+    const radius = Math.min(w, h) * 0.03;
+
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + bw - radius, y);
+    ctx.quadraticCurveTo(x + bw, y, x + bw, y + radius);
+    ctx.lineTo(x + bw, y + bh - radius);
+    ctx.quadraticCurveTo(x + bw, y + bh, x + bw - radius, y + bh);
+    ctx.lineTo(x + radius, y + bh);
+    ctx.quadraticCurveTo(x, y + bh, x, y + bh - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(w * 0.38, h * 0.74);
+    ctx.lineTo(w * 0.62, h * 0.74);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(w * 0.45, h * 0.65);
+    ctx.lineTo(w * 0.55, h * 0.65);
+    ctx.lineTo(w * 0.62, h * 0.74);
+    ctx.lineTo(w * 0.38, h * 0.74);
+    ctx.closePath();
+    ctx.stroke();
+  } else if (kind === "pencil") {
+    const cx = w * 0.5;
+    const cy = h * 0.5;
+    const len = Math.min(w, h) * 0.62;
+    const thick = Math.min(w, h) * 0.11;
+    const angle = -Math.PI / 5;
+
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate(angle);
+
+    ctx.strokeRect(-len * 0.4, -thick / 2, len * 0.65, thick);
+
+    ctx.beginPath();
+    ctx.moveTo(len * 0.25, -thick / 2);
+    ctx.lineTo(len * 0.4, 0);
+    ctx.lineTo(len * 0.25, thick / 2);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(-len * 0.4, -thick / 2);
+    ctx.lineTo(-len * 0.54, -thick / 2);
+    ctx.lineTo(-len * 0.54, thick / 2);
+    ctx.lineTo(-len * 0.4, thick / 2);
+    ctx.closePath();
+    ctx.stroke();
+
+    ctx.restore();
+  }
+
+  const imageData = ctx.getImageData(0, 0, w, h).data;
+  const points = [];
+  const step = isMobile ? 7 : 5;
+
+  for (let y = 0; y < h; y += step) {
+    for (let x = 0; x < w; x += step) {
+      const alpha = imageData[(y * w + x) * 4 + 3];
+      if (alpha > 20) {
+        points.push({ x: x + (width - w) / 2, y: y + (height - h) / 2 });
+      }
+    }
+  }
+
+  return points;
+}
+
+function App() {
+  const canvasRef = useRef(null);
+  const [shapeLabel, setShapeLabel] = useState("Globe");
+  const [quoteIndex, setQuoteIndex] = useState(0);
+
+  const quotes = [
+    "art, technology, marketing",
+    "Stories designed at the intersection of code and culture.",
+    "Creative systems for human connection.",
+    "From concept to campaign, crafted with intention."
+  ];
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setQuoteIndex((prev) => (prev + 1) % quotes.length);
+    }, 3600);
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+    let isMobile = width <= 768;
+
+    const names = ["globe", "face", "mac", "pencil"];
+    const displayNames = {
+      globe: "Globe",
+      face: "Face",
+      mac: "Mac",
+      pencil: "Pencil"
+    };
+
+    const particleCount = isMobile ? 700 : 1300;
+    const particles = Array.from({ length: particleCount }).map(() => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      vx: 0,
+      vy: 0,
+      tx: width / 2,
+      ty: height / 2
+    }));
+
+    let shapeIndex = 0;
+
+    const assignTargets = () => {
+      const targets = makePointsForShape(names[shapeIndex], width, height, isMobile);
+      for (let i = 0; i < particles.length; i += 1) {
+        const target = targets[i % targets.length];
+        particles[i].tx = target.x;
+        particles[i].ty = target.y;
+      }
+      setShapeLabel(displayNames[names[shapeIndex]]);
+    };
+
+    assignTargets();
+
+    const mouse = { x: -9999, y: -9999, active: false };
+
+    const setSize = () => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      isMobile = width <= 768;
+
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      assignTargets();
+    };
+
+    setSize();
+
+    const onMouseMove = (e) => {
+      mouse.x = e.clientX;
+      mouse.y = e.clientY;
+      mouse.active = true;
+    };
+
+    const onTouchMove = () => {
+      mouse.active = false;
+    };
+
+    const onLeave = () => {
+      mouse.active = false;
+    };
+
+    window.addEventListener("resize", setSize);
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    window.addEventListener("mouseleave", onLeave);
+
+    const shapeTimer = setInterval(() => {
+      shapeIndex = (shapeIndex + 1) % names.length;
+      assignTargets();
+    }, isMobile ? 3400 : 2800);
+
+    let raf = null;
+    const animate = () => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "rgba(113, 199, 255, 0.9)";
+
+      const safeHalfW = isMobile ? 135 : 260;
+      const safeHalfH = isMobile ? 70 : 120;
+      const centerX = width * 0.5;
+      const centerY = height * 0.5;
+
+      for (let i = 0; i < particles.length; i += 1) {
+        const p = particles[i];
+        const dx = p.tx - p.x;
+        const dy = p.ty - p.y;
+
+        p.vx += dx * 0.008;
+        p.vy += dy * 0.008;
+
+        if (mouse.active && !isMobile) {
+          const mx = p.x - mouse.x;
+          const my = p.y - mouse.y;
+          const dist2 = mx * mx + my * my;
+          const radius = 110;
+          if (dist2 < radius * radius) {
+            const push = (radius * radius - dist2) / (radius * radius);
+            const angle = Math.atan2(my, mx);
+            p.vx += Math.cos(angle) * push * 1.2;
+            p.vy += Math.sin(angle) * push * 1.2;
+          }
+        }
+
+        const inSafeZone =
+          Math.abs(p.x - centerX) < safeHalfW &&
+          Math.abs(p.y - centerY) < safeHalfH;
+        if (inSafeZone) {
+          const awayX = p.x >= centerX ? 1 : -1;
+          const awayY = p.y >= centerY ? 1 : -1;
+          p.vx += awayX * 0.7;
+          p.vy += awayY * 0.5;
+        }
+
+        p.vx *= 0.84;
+        p.vy *= 0.84;
+        p.x += p.vx;
+        p.y += p.vy;
+
+        ctx.fillRect(p.x, p.y, isMobile ? 1.8 : 2.2, isMobile ? 1.8 : 2.2);
+      }
+
+      raf = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      clearInterval(shapeTimer);
+      window.removeEventListener("resize", setSize);
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("mouseleave", onLeave);
+    };
+  }, []);
+
+  return React.createElement(
+    "div",
+    { className: "site" },
+    React.createElement("canvas", { ref: canvasRef, "aria-hidden": "true" }),
+    React.createElement(
+      "nav",
+      { className: "nav", "aria-label": "Main" },
+      React.createElement(
+        "a",
+        { href: "https://marketingos.blog", target: "_blank", rel: "noreferrer" },
+        "Blog"
+      ),
+      React.createElement("a", { href: "/about/" }, "About")
+    ),
+    React.createElement(
+      "main",
+      { className: "centerpiece" },
+      React.createElement(
+        "div",
+        { className: "center-card" },
+        React.createElement("h1", null, "Fangzhi Zhao"),
+        React.createElement("p", { className: "tagline" }, quotes[quoteIndex]),
+        React.createElement("p", { className: "shape" }, "Interactive particles: ", shapeLabel)
+      )
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(React.createElement(App));


### PR DESCRIPTION
### Motivation

- Modernize the site by replacing the old static landing page with an interactive, particle-based React landing experience.
- Provide a proper `/about/` scaffold and preserve the original GitHub Pages content under `/first-github-page/` for archival access.
- Centralize styling for the new UI with a dedicated stylesheet to keep visuals consistent across pages.

### Description

- Replaced the legacy `index.html` with a new shell that loads `css/site.css`, React, and `js/app.js` to render the interactive landing experience.
- Added `js/app.js`, a React-based particle animation app that renders a canvas, navigation links, rotating shapes, and dynamic copy.
- Added `css/site.css` for global site styles and UI components used by the new landing and navigation.
- Added an `about/index.html` page with a styled static About scaffold and added `first-github-page/index.html` to preserve the original archived page.
- Updated `README.md` to document the site structure and external links.

### Testing

- No automated tests are configured or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d45defc740832eb7cd9988c3ccf058)