### PR TITLE
Remove glassmorphism card and nav borders for open void aesthetic

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -50,29 +50,17 @@ canvas {
 }
 
 .nav a {
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  background: linear-gradient(
-    140deg,
-    rgba(255, 255, 255, 0.16) 0%,
-    rgba(255, 255, 255, 0.04) 45%,
-    rgba(255, 255, 255, 0.08) 100%
-  );
-  color: var(--text);
-  border-radius: 999px;
-  padding: 0.56rem 1rem;
+  color: rgba(236, 242, 255, 0.55);
   font-size: 0.9rem;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.06em;
   text-decoration: none;
-  backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.26), 0 10px 30px rgba(0, 0, 0, 0.28);
-  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  text-transform: uppercase;
+  padding: 0.56rem 0.6rem;
+  transition: color 0.2s ease;
 }
 
 .nav a:hover {
-  transform: translateY(-1px);
-  border-color: rgba(113, 199, 255, 0.9);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.34), 0 0 20px rgba(113, 199, 255, 0.24);
+  color: var(--text);
 }
 
 .centerpiece {
@@ -86,26 +74,18 @@ canvas {
 }
 
 .center-card {
-  background: linear-gradient(
-    155deg,
-    rgba(255, 255, 255, 0.14),
-    rgba(255, 255, 255, 0.04) 35%,
-    rgba(8, 11, 19, 0.55) 100%
-  );
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  border-radius: 18px;
   padding: clamp(1rem, 3vw, 1.4rem) clamp(1.1rem, 4vw, 1.8rem);
   min-width: min(86vw, 560px);
-  backdrop-filter: blur(12px) saturate(140%);
-  -webkit-backdrop-filter: blur(12px) saturate(140%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 18px 55px rgba(0, 0, 0, 0.45);
 }
 
 .centerpiece h1 {
   margin: 0;
   font-size: clamp(2.1rem, 7.8vw, 5rem);
   letter-spacing: 0.03em;
-  text-shadow: 0 8px 40px rgba(113, 199, 255, 0.22);
+  text-shadow:
+    0 0 80px rgba(8, 11, 19, 0.9),
+    0 0 40px rgba(8, 11, 19, 0.7),
+    0 8px 40px rgba(113, 199, 255, 0.18);
 }
 
 .tagline {
@@ -113,12 +93,14 @@ canvas {
   margin-bottom: 0.3rem;
   color: #dce6fa;
   font-size: clamp(1rem, 2.3vw, 1.2rem);
+  text-shadow: 0 0 40px rgba(8, 11, 19, 0.8);
 }
 
 .shape {
   margin: 0;
   color: var(--muted);
   font-size: clamp(0.85rem, 2vw, 1rem);
+  text-shadow: 0 0 30px rgba(8, 11, 19, 0.8);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
Strip the glass card from the center hero and pill borders from nav links so text floats directly in the particle field. Add dark text shadows for legibility without a backing container.